### PR TITLE
Client types objsupport

### DIFF
--- a/client/src/components/dTypeBrowse.vue
+++ b/client/src/components/dTypeBrowse.vue
@@ -20,21 +20,23 @@
                         <v-container grid-list-md>
                             <v-layout wrap>
                                 <template v-for="header in headers">
-                                    <v-flex xs12 v-if="header.value === 'types'">
+                                    <v-flex xs12
+                                        v-if="header.value === 'types' || header.value === 'optionals' || header.value === 'outputs'"
+                                    >
                                         <v-layout row wrap>
                                             <dTypeTypeEdit
-                                                v-for="(type, i) in editedItem.types"
+                                                v-for="(type, i) in editedItem[header.value]"
                                                 :type="type"
-                                                v-on:change="onChangedType($event, i)"
-                                                v-on:remove="onRemovedType(type, i)"
+                                                v-on:change="onChangedType(header.value, $event, i)"
+                                                v-on:remove="onRemovedType(header.value,type, i)"
                                             />
                                             <v-flex xs12>
                                                 <dTypeSearch
-                                                    label='types'
+                                                    :label='header.value'
                                                     itemKey='name'
                                                     itemValue='name'
                                                     :items='items'
-                                                    v-on:change="onSelectedType"
+                                                    v-on:change="onSelectedType(header.value, $event)"
                                                 />
                                             </v-flex>
                                         </v-layout>
@@ -221,7 +223,7 @@ export default {
                     if (header) {
                         let dtype = this.$store.state.dtypes.find(dtype => dtype.name === header.type.name);
 
-                        if (dtype && dtype.types.length && key !== 'types') {
+                        if (dtype && dtype.types.length && ['types', 'optionals', 'outputs'].indexOf(key) === -1 ) {
                             item[key] = JSON.stringify(item[key]);
                         }
 
@@ -229,6 +231,14 @@ export default {
                 });
             if (item.types) {
                 item.types = item.types.map(type => {
+                    type.dimensions = JSON.stringify(type.dimensions);
+                    return type;
+                });
+                item.optionals = item.optionals.map(type => {
+                    type.dimensions = JSON.stringify(type.dimensions);
+                    return type;
+                });
+                item.outputs = item.outputs.map(type => {
                     type.dimensions = JSON.stringify(type.dimensions);
                     return type;
                 });
@@ -267,7 +277,15 @@ export default {
                 this.editedItem.types = this.editedItem.types.map(type => {
                     type.dimensions = JSON.parse(type.dimensions);
                     return type;
-                })
+                });
+                this.editedItem.optionals = this.editedItem.optionals.map(type => {
+                    type.dimensions = JSON.parse(type.dimensions);
+                    return type;
+                });
+                this.editedItem.outputs = this.editedItem.outputs.map(type => {
+                    type.dimensions = JSON.parse(type.dimensions);
+                    return type;
+                });
             }
             if (this.editedIndex > -1) {
                 this.update(this.editedItem);
@@ -289,17 +307,17 @@ export default {
                 alert(`${e}`);
             }
         },
-        onSelectedType(values) {
-            values = this.editedItem.types.concat(values.map((value) => {
+        onSelectedType(key, values) {
+            values = this.editedItem[key].concat(values.map((value) => {
                 return {name: value, label: '', relation: 0, dimensions: []};
             }));
-            this.editedItem.types = values;
+            this.editedItem[key] = values;
         },
-        onChangedType(changed, i) {
-            this.editedItem.types[i][changed[0]] = changed[1];
+        onChangedType(key, changed, i) {
+            this.editedItem[key][i][changed[0]] = changed[1];
         },
-        onRemovedType(value, i) {
-            this.editedItem.types.splice(i, 1);
+        onRemovedType(key, value, i) {
+            this.editedItem[key].splice(i, 1);
         },
     },
 };

--- a/client/src/components/dTypeSearch.vue
+++ b/client/src/components/dTypeSearch.vue
@@ -11,7 +11,6 @@
                 :item-text="itemKey"
                 :item-value="itemValue"
                 :return-object="returnObject"
-                placeholder="uint256"
                 append-icon="search"
                 no-data-text=""
                 multiple

--- a/client/src/components/dTypeTypeEdit.vue
+++ b/client/src/components/dTypeTypeEdit.vue
@@ -1,0 +1,44 @@
+<template>
+    <v-flex xs4>
+    <v-card>
+        <v-flex xs2 offset-xs8>
+            <v-btn fab small>
+                <v-icon @click="onRemove()">close</v-icon>
+            </v-btn>
+        </v-flex>
+        <v-flex xs12 v-for='key in Object.keys(changedType)'>
+            <v-text-field
+                :value='changedType[key]'
+                :label='key'
+                :readonly='key == "name" ? true : false'
+                v-on:input="onChange(key, $event)"
+            >
+            </v-text-field>
+        </v-flex>
+    </v-card>
+    </v-flex>
+</template>
+
+<script>
+export default {
+    props: ['type'],
+    data() {
+        return {
+            changedType: Object.assign({}, this.type),
+        }
+    },
+    updated: {
+        type() {
+            this.changedType = Object.assign({}, this.type);
+        },
+    },
+    methods: {
+        onChange(key, value) {
+            this.$emit('change', [key, value]);
+        },
+        onRemove() {
+            this.$emit('remove');
+        },
+    }
+}
+</script>

--- a/client/src/views/dTypeLandingPage.vue
+++ b/client/src/views/dTypeLandingPage.vue
@@ -115,9 +115,6 @@ export default {
                 }
             }
             this.defaultItem = buildDefaultItem(this.typeStruct);
-            if (this.defaultItem.types) {
-                this.defaultItem.labels = [];
-            }
         },
         async watchAll() {
             this.typeContract.on('LogNew', async (typeHash, index) => {

--- a/contracts/data/dtypes_core.json
+++ b/contracts/data/dtypes_core.json
@@ -4,7 +4,8 @@
         "types": [
             {"name": "string", "label": "name", "relation":0, "dimensions":[]},
             {"name": "string", "label": "label", "relation":0, "dimensions":[]},
-            {"name": "uint8", "label": "relation", "relation":0, "dimensions":[]}
+            {"name": "uint8", "label": "relation", "relation":0, "dimensions":[]},
+            {"name": "string", "label": "dimensions", "relation":0, "dimensions":["0"]}
         ],
         "optionals": [],
         "outputs": [],


### PR DESCRIPTION
fixes https://github.com/ctzurcanu/dType/issues/59 Support optional components in the client
fixes https://github.com/ctzurcanu/dType/issues/56 Add UI support for array types
fixes https://github.com/ctzurcanu/dType/issues/27 dType browse - combine types & labels into one field
fixes https://github.com/ctzurcanu/dType/issues/9 Add outputs in types add form if isFunction is true

Types, optionals & outputs are treated in the same way and we can now add, edit, remove `dTypes` objects.

