### PR TITLE
Filesystem storage pointers

### DIFF
--- a/contracts/contracts/examples/filesystem/FSPureFunctions.sol
+++ b/contracts/contracts/examples/filesystem/FSPureFunctions.sol
@@ -11,7 +11,7 @@ contract FSPureFunctions {
         public
         returns (FileTypeLib.FileType memory changedFile)
     {
-        file.name = string(abi.encodePacked(file.name, "1"));
+        file.pointer.name = string(abi.encodePacked(file.pointer.name, "1"));
         return file;
     }
 }

--- a/contracts/contracts/examples/filesystem/FilePointerLib.sol
+++ b/contracts/contracts/examples/filesystem/FilePointerLib.sol
@@ -1,0 +1,91 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+// import './ExtensionLib.sol';
+import './SwarmPointerLib.sol';
+import './IpfsPointerLib.sol';
+import './UriPointerLib.sol';
+
+library FilePointerLib {
+
+    struct FilePointerRequired {
+        string name;
+        // ExtensionLib.Extension extension;
+        uint8 extension;
+    }
+
+    struct FilePointer {
+        string name;
+        uint8 extension;
+        SwarmPointerLib.SwarmPointer swarm;
+        IpfsPointerLib.IpfsPointer ipfs;
+        UriPointerLib.UriPointer uri;
+    }
+
+    function insert(FilePointerRequired storage self, FilePointer memory pointer) internal {
+        self.name = pointer.name;
+        self.extension = pointer.extension;
+    }
+
+    function insertArray(FilePointerRequired[] storage self, FilePointer[] memory pointers) internal {
+        uint256 length = pointers.length;
+        for (uint256 i = 0; i < length; i++) {
+            insert(self[i], pointers[i]);
+        }
+    }
+
+    function getDataHash(FilePointer memory pointer) pure public returns(bytes32 hash) {
+        return keccak256(abi.encode(pointer));
+    }
+
+    function getFull(
+        FilePointerRequired memory pointer,
+        SwarmPointerLib.SwarmPointer memory swarm,
+        IpfsPointerLib.IpfsPointer memory ipfs,
+        UriPointerLib.UriPointer memory uri
+    )
+        pure
+        public
+        returns(FilePointer memory pointerFull)
+    {
+        return FilePointer(pointer.name, pointer.extension, swarm, ipfs, uri);
+    }
+
+    function structureBytes(bytes memory data)
+        pure
+        public
+        returns(FilePointer memory pointer)
+    {
+        (pointer) = abi.decode(data, (FilePointer));
+    }
+
+    function destructureBytes(FilePointer memory pointer)
+        pure
+        public
+        returns(bytes memory data)
+    {
+        return abi.encode(pointer);
+    }
+
+    function map(
+        address callbackAddr,
+        bytes4 callbackSig,
+        FilePointer[] memory pointerArr
+    )
+        view
+        public
+        returns (FilePointer[] memory result)
+    {
+        uint length = pointerArr.length;
+        result = new FilePointer[](length);
+
+        for (uint i = 0; i < length; i++) {
+            (bool success, bytes memory data) = callbackAddr.staticcall(abi.encodeWithSelector(callbackSig, pointerArr[i]));
+
+            require(success, "Map callback failed");
+            result[i] = structureBytes(data);
+        }
+
+        return result;
+    }
+}

--- a/contracts/contracts/examples/filesystem/FilePointerStorage.sol
+++ b/contracts/contracts/examples/filesystem/FilePointerStorage.sol
@@ -1,0 +1,96 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import './SwarmPointerLib.sol';
+import './IpfsPointerLib.sol';
+import './UriPointerLib.sol';
+import './FilePointerLib.sol';
+
+contract FilePointerStorage {
+    using FilePointerLib for FilePointerLib.FilePointer;
+    using FilePointerLib for FilePointerLib.FilePointerRequired;
+
+    bytes32[] public typeIndex;
+    mapping(bytes32 => Type) public typeStruct;
+
+    // Used for folders, to keep references to their files
+    mapping(bytes32 => SwarmPointerLib.SwarmPointer) public swarm;
+    mapping(bytes32 => IpfsPointerLib.IpfsPointer) public ipfs;
+    mapping(bytes32 => UriPointerLib.UriPointer) public uri;
+
+    struct Type {
+        FilePointerLib.FilePointerRequired data;
+        uint256 index;
+    }
+
+    modifier dataIsStored (bytes32 hash) {
+        require(isStored(hash), "No such data inserted.");
+        _;
+    }
+
+    event LogNew(bytes32 indexed hash, uint256 indexed index);
+    event LogUpdate(bytes32 indexed hash, uint256 indexed index);
+    event LogRemove(bytes32 indexed hash, uint256 indexed index);
+
+    function insert(FilePointerLib.FilePointer memory data) public returns (bytes32 hasho) {
+
+        // for data integrity
+        bytes32 hash = data.getDataHash();
+
+        if(isStored(hash)) revert("This data exists. Use the extant data.");
+
+        typeStruct[hash].data.insert(data);
+        typeStruct[hash].index = typeIndex.push(hash) - 1;
+
+        swarm[hash] = data.swarm;
+        ipfs[hash] = data.ipfs;
+        uri[hash] = data.uri;
+
+        emit LogNew(hash, typeStruct[hash].index);
+        return hash;
+    }
+
+    function insertBytes(bytes memory data) public returns (bytes32 hasho) {
+        return insert(FilePointerLib.structureBytes(data));
+    }
+
+    function remove(bytes32 hash) public returns(uint256 index) {
+        if(!isStored(hash)) revert("Not deleted: not extant.");
+        uint rowToDelete = typeStruct[hash].index;
+        bytes32 keyToMove = typeIndex[typeIndex.length-1];
+        typeIndex[rowToDelete] = keyToMove;
+        typeStruct[keyToMove].index = rowToDelete;
+        typeIndex.length--;
+
+        delete swarm[hash];
+        delete ipfs[hash];
+        delete uri[hash];
+
+        emit LogRemove(hash, rowToDelete);
+
+        emit LogUpdate(keyToMove, rowToDelete);
+        return rowToDelete;
+    }
+
+    function update(bytes32 hashi, FilePointerLib.FilePointer memory data)
+        public
+        returns(bytes32 hash)
+    {
+        remove(hashi);
+        return insert(data);
+    }
+
+    function isStored(bytes32 hash) public view returns(bool isIndeed) {
+        if(typeIndex.length == 0) return false;
+        return (typeIndex[typeStruct[hash].index] == hash);
+    }
+
+    function getByHash(bytes32 hash) public view returns(FilePointerLib.FilePointer memory data) {
+        if(!isStored(hash)) revert("No such data inserted.");
+        return typeStruct[hash].data.getFull(swarm[hash], ipfs[hash], uri[hash]);
+    }
+
+    function count() public view returns(uint256 counter) {
+        return typeIndex.length;
+    }
+}

--- a/contracts/contracts/examples/filesystem/FileTypeLib.sol
+++ b/contracts/contracts/examples/filesystem/FileTypeLib.sol
@@ -1,30 +1,24 @@
 pragma solidity ^0.5.0;
 pragma experimental ABIEncoderV2;
 
-// import './ExtensionLib.sol';
+import './FilePointerLib.sol';
 
 library FileTypeLib {
+    using FilePointerLib for FilePointerLib.FilePointer;
 
     struct FileTypeRequired {
-        string name;
-        // ExtensionLib.Extension extension;
-        uint8 extension;
-        string source;  // swarm/ipfs url; will be a type in itself
+        FilePointerLib.FilePointer pointer;
         bytes32 parentKey;  // string path
     }
 
     struct FileType {
-        string name;
-        uint8 extension;
-        string source;
+        FilePointerLib.FilePointer pointer;
         bytes32 parentKey;
         bytes32[] filesPerFolder;
     }
 
     function insert(FileTypeRequired storage self, FileType memory file) internal {
-        self.name = file.name;
-        self.extension = file.extension;
-        self.source = file.source;
+        self.pointer = file.pointer;
         self.parentKey = file.parentKey;
     }
 
@@ -41,18 +35,14 @@ library FileTypeLib {
 
     function getRequired(FileType memory fileFull) pure public returns(FileTypeRequired memory file) {
         return FileTypeRequired(
-            fileFull.name,
-            fileFull.extension,
-            fileFull.source,
+            fileFull.pointer,
             fileFull.parentKey
         );
     }
 
     function getFull(FileTypeRequired memory file, bytes32[] memory filesPerFolder) pure public returns(FileType memory fileFull) {
         return FileType(
-            file.name,
-            file.extension,
-            file.source,
+            file.pointer,
             file.parentKey,
             filesPerFolder
         );

--- a/contracts/contracts/examples/filesystem/IpfsPointerLib.sol
+++ b/contracts/contracts/examples/filesystem/IpfsPointerLib.sol
@@ -1,0 +1,78 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+library IpfsPointerLib {
+
+    enum Protocol {
+        IPFS
+    }
+
+    struct IpfsPointer {
+        Protocol protocol;
+        bytes32 filehash;
+    }
+
+    function insert(IpfsPointer storage self, IpfsPointer memory pointer) internal {
+        if (pointer.filehash != bytes32(0x0)) {
+            self.protocol = pointer.protocol;
+            self.filehash = pointer.filehash;
+        }
+    }
+
+    function insertArray(IpfsPointer[] storage self, IpfsPointer[] memory pointer) internal {
+        uint256 length = pointer.length;
+        for (uint256 i = 0; i < length; i++) {
+            insert(self[i], pointer[i]);
+        }
+    }
+
+    function getDataHash(IpfsPointer memory pointer) pure public returns(bytes32 hash) {
+        return keccak256(abi.encode(pointer));
+    }
+
+    function getRequired(IpfsPointer memory pointer) pure public returns(IpfsPointer memory pointerRequired) {
+        return pointer;
+    }
+
+    function getFull(IpfsPointer memory pointer) pure public returns(IpfsPointer memory pointerFull) {
+        return pointer;
+    }
+
+    function structureBytes(bytes memory data)
+        pure
+        public
+        returns(IpfsPointer memory pointer)
+    {
+        (pointer) = abi.decode(data, (IpfsPointer));
+    }
+
+    function destructureBytes(IpfsPointer memory pointer)
+        pure
+        public
+        returns(bytes memory data)
+    {
+        return abi.encode(pointer);
+    }
+
+    function map(
+        address callbackAddr,
+        bytes4 callbackSig,
+        IpfsPointer[] memory pointerArr
+    )
+        view
+        public
+        returns (IpfsPointer[] memory result)
+    {
+        uint length = pointerArr.length;
+        result = new IpfsPointer[](length);
+
+        for (uint i = 0; i < length; i++) {
+            (bool success, bytes memory data) = callbackAddr.staticcall(abi.encodeWithSelector(callbackSig, pointerArr[i]));
+
+            require(success, "Map callback failed");
+            result[i] = structureBytes(data);
+        }
+
+        return result;
+    }
+}

--- a/contracts/contracts/examples/filesystem/SwarmPointerLib.sol
+++ b/contracts/contracts/examples/filesystem/SwarmPointerLib.sol
@@ -1,0 +1,79 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+library SwarmPointerLib {
+
+    enum Protocol {
+        BZZ,
+        BZZRAW
+    }
+
+    struct SwarmPointer {
+        Protocol protocol;
+        bytes32 filehash;
+    }
+
+    function insert(SwarmPointer storage self, SwarmPointer memory pointer) internal {
+        if (pointer.filehash != bytes32(0x0)) {
+            self.protocol = pointer.protocol;
+            self.filehash = pointer.filehash;
+        }
+    }
+
+    function insertArray(SwarmPointer[] storage self, SwarmPointer[] memory pointer) internal {
+        uint256 length = pointer.length;
+        for (uint256 i = 0; i < length; i++) {
+            insert(self[i], pointer[i]);
+        }
+    }
+
+    function getDataHash(SwarmPointer memory pointer) pure public returns(bytes32 hash) {
+        return keccak256(abi.encode(pointer));
+    }
+
+    function getRequired(SwarmPointer memory pointer) pure public returns(SwarmPointer memory pointerRequired) {
+        return pointer;
+    }
+
+    function getFull(SwarmPointer memory pointer) pure public returns(SwarmPointer memory pointerFull) {
+        return pointer;
+    }
+
+    function structureBytes(bytes memory data)
+        pure
+        public
+        returns(SwarmPointer memory pointer)
+    {
+        (pointer) = abi.decode(data, (SwarmPointer));
+    }
+
+    function destructureBytes(SwarmPointer memory pointer)
+        pure
+        public
+        returns(bytes memory data)
+    {
+        return abi.encode(pointer);
+    }
+
+    function map(
+        address callbackAddr,
+        bytes4 callbackSig,
+        SwarmPointer[] memory pointerArr
+    )
+        view
+        public
+        returns (SwarmPointer[] memory result)
+    {
+        uint length = pointerArr.length;
+        result = new SwarmPointer[](length);
+
+        for (uint i = 0; i < length; i++) {
+            (bool success, bytes memory data) = callbackAddr.staticcall(abi.encodeWithSelector(callbackSig, pointerArr[i]));
+
+            require(success, "Map callback failed");
+            result[i] = structureBytes(data);
+        }
+
+        return result;
+    }
+}

--- a/contracts/contracts/examples/filesystem/UriPointerLib.sol
+++ b/contracts/contracts/examples/filesystem/UriPointerLib.sol
@@ -1,0 +1,72 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+library UriPointerLib {
+
+    struct UriPointer {
+        string uri;
+    }
+
+    function insert(UriPointer storage self, UriPointer memory pointer) internal {
+        if (keccak256(abi.encodePacked(pointer.uri)) != keccak256(abi.encodePacked(""))) {
+            self.uri = pointer.uri;
+        }
+    }
+
+    function insertArray(UriPointer[] storage self, UriPointer[] memory pointer) internal {
+        uint256 length = pointer.length;
+        for (uint256 i = 0; i < length; i++) {
+            insert(self[i], pointer[i]);
+        }
+    }
+
+    function getDataHash(UriPointer memory pointer) pure public returns(bytes32 hash) {
+        return keccak256(abi.encode(pointer));
+    }
+
+    function getRequired(UriPointer memory pointer) pure public returns(UriPointer memory pointerRequired) {
+        return pointer;
+    }
+
+    function getFull(UriPointer memory pointer) pure public returns(UriPointer memory pointerFull) {
+        return pointer;
+    }
+
+    function structureBytes(bytes memory data)
+        pure
+        public
+        returns(UriPointer memory pointer)
+    {
+        (pointer) = abi.decode(data, (UriPointer));
+    }
+
+    function destructureBytes(UriPointer memory pointer)
+        pure
+        public
+        returns(bytes memory data)
+    {
+        return abi.encode(pointer);
+    }
+
+    function map(
+        address callbackAddr,
+        bytes4 callbackSig,
+        UriPointer[] memory pointerArr
+    )
+        view
+        public
+        returns (UriPointer[] memory result)
+    {
+        uint length = pointerArr.length;
+        result = new UriPointer[](length);
+
+        for (uint i = 0; i < length; i++) {
+            (bool success, bytes memory data) = callbackAddr.staticcall(abi.encodeWithSelector(callbackSig, pointerArr[i]));
+
+            require(success, "Map callback failed");
+            result[i] = structureBytes(data);
+        }
+
+        return result;
+    }
+}

--- a/contracts/data/dtypes_fs.json
+++ b/contracts/data/dtypes_fs.json
@@ -1,10 +1,63 @@
 [
     {
-        "name": "FileType",
+        "name": "SwarmPointer",
+        "types": [
+            {"name": "uint8", "label": "protocol", "relation": 0, "dimensions":[]},
+            {"name": "bytes32", "label": "filehash", "relation": 0, "dimensions":[]}
+        ],
+        "optionals": [],
+        "outputs": [],
+        "lang": 0,
+        "typeChoice": 0,
+        "contractAddress": "0x0000000000000000000000000000000000000000",
+        "source": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+        "name": "IpfsPointer",
+        "types": [
+            {"name": "uint8", "label": "protocol", "relation": 0, "dimensions":[]},
+            {"name": "bytes32", "label": "filehash", "relation": 0, "dimensions":[]}
+        ],
+        "optionals": [],
+        "outputs": [],
+        "lang": 0,
+        "typeChoice": 0,
+        "contractAddress": "0x0000000000000000000000000000000000000000",
+        "source": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+        "name": "UriPointer",
+        "types": [
+            {"name": "string", "label": "uri", "relation": 0, "dimensions":[]}
+        ],
+        "optionals": [],
+        "outputs": [],
+        "lang": 0,
+        "typeChoice": 0,
+        "contractAddress": "0x0000000000000000000000000000000000000000",
+        "source": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+        "name": "FilePointer",
         "types": [
             {"name": "string", "label": "name", "relation": 0, "dimensions":[]},
-            {"name": "uint8", "label": "extension", "relation": 0, "dimensions":[]},
-            {"name": "string", "label": "source", "relation": 0, "dimensions":[]},
+            {"name": "uint8", "label": "extension", "relation": 0, "dimensions":[]}
+        ],
+        "optionals": [
+            {"name": "SwarmPointer", "label": "swarm", "relation": 0, "dimensions":[]},
+            {"name": "IpfsPointer", "label": "ipfs", "relation": 0, "dimensions":[]},
+            {"name": "UriPointer", "label": "uri", "relation": 0, "dimensions":[]}
+        ],
+        "outputs": [],
+        "lang": 0,
+        "typeChoice": 0,
+        "contractAddress": "0x0000000000000000000000000000000000000000",
+        "source": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+        "name": "FileType",
+        "types": [
+            {"name": "FilePointer", "label": "pointer", "relation": 0, "dimensions":[]},
             {"name": "bytes32", "label": "parentKey", "relation": 0, "dimensions":[]}
         ],
         "optionals": [

--- a/contracts/data/fs_data.json
+++ b/contracts/data/fs_data.json
@@ -2,9 +2,15 @@
     "folders": [
         {
             "folder": {
-                "name": "Root",
-                "extension": 0,
-                "source": "/bzz-raw:/9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189/",
+                "pointer": {
+                    "name": "Root",
+                    "extension": 0,
+                    "swarm": {
+                        "protocol": 1,
+                        "filehash": "0x9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189"
+                    },
+                    "ipfs": {"protocol": 0, "filehash": "0x0000000000000000000000000000000000000000000000000000000000000000"}, "uri": {"uri": ""}
+                },
                 "parentKey": null,
                 "filesPerFolder": []
             },
@@ -12,40 +18,70 @@
         },
         {
             "folder": {
-                "name": "Folder1",
-                "extension": 0,
-                "source": "/bzz-raw:/9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189/",
+                "pointer": {
+                    "name": "Folder1",
+                    "extension": 0,
+                    "swarm": {
+                        "protocol": 1,
+                        "filehash": "0x9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189"
+                    },
+                    "ipfs": {"protocol": 0, "filehash": "0x0000000000000000000000000000000000000000000000000000000000000000"}, "uri": {"uri": ""}
+                },
                 "parentKey": 0,
                 "filesPerFolder": []
             },
             "files": [
                 {
-                    "name": "File1",
-                    "extension": 1,
-                    "source": "/bzz-raw:/9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189/",
+                    "pointer": {
+                        "name": "File1",
+                        "extension": 1,
+                        "swarm": {
+                            "protocol": 1,
+                            "filehash": "0x9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189"
+                        },
+                        "ipfs": {"protocol": 0, "filehash": "0x0000000000000000000000000000000000000000000000000000000000000000"}, "uri": {"uri": ""}
+                    },
                     "filesPerFolder": []
                 },
                 {
-                    "name": "File2",
-                    "extension": 1,
-                    "source": "/bzz-raw:/9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189/",
+                    "pointer": {
+                        "name": "File2",
+                        "extension": 1,
+                        "swarm": {
+                            "protocol": 1,
+                            "filehash": "0x9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189"
+                        },
+                        "ipfs": {"protocol": 0, "filehash": "0x0000000000000000000000000000000000000000000000000000000000000000"}, "uri": {"uri": ""}
+                    },
                     "filesPerFolder": []
                 }
             ]
         },
         {
             "folder": {
-                "name": "Folder2",
-                "extension": 0,
-                "source": "/bzz-raw:/9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189/",
+                "pointer": {
+                    "name": "Folder2",
+                    "extension": 0,
+                    "swarm": {
+                        "protocol": 1,
+                        "filehash": "0x9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189"
+                    },
+                    "ipfs": {"protocol": 0, "filehash": "0x0000000000000000000000000000000000000000000000000000000000000000"}, "uri": {"uri": ""}
+                },
                 "parentKey": 0,
                 "filesPerFolder": []
             },
             "files": [
                 {
-                    "name": "File3",
-                    "extension": 1,
-                    "source": "/bzz-raw:/9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189/",
+                    "pointer": {
+                        "name": "File3",
+                        "extension": 1,
+                        "swarm": {
+                            "protocol": 1,
+                            "filehash": "0x9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189"
+                        },
+                        "ipfs": {"protocol": 0, "filehash": "0x0000000000000000000000000000000000000000000000000000000000000000"}, "uri": {"uri": ""}
+                    },
                     "parentKey": 2,
                     "filesPerFolder": []
                 }
@@ -54,9 +90,15 @@
     ],
     "files": [
         {
-            "name": "File4",
-            "extension": 1,
-            "source": "/bzz-raw:/9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189/",
+            "pointer": {
+                "name": "File4",
+                "extension": 1,
+                "swarm": {
+                    "protocol": 1,
+                    "filehash": "0x9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189"
+                },
+                "ipfs": {"protocol": 0, "filehash": "0x0000000000000000000000000000000000000000000000000000000000000000"}, "uri": {"uri": ""}
+            },
             "parentKey": null,
             "filesPerFolder": []
         }

--- a/contracts/test/dtype_fs.js
+++ b/contracts/test/dtype_fs.js
@@ -32,16 +32,27 @@ contract('filesystem', async (accounts) => {
         let logs, folderHash, fileHash;
         let changedFile;
         let file = {
-            "name": "TestFile",
-            "extension": 1,
-            "source": "/bzz-raw:/9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189/",
-            "parentKey": null,
+            "pointer": {
+                "name": "TestFile",
+                "extension": 1,
+                "swarm": {
+                    "protocol": 1,
+                    "filehash": "0x9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189"
+                },
+                "ipfs": {"protocol": 0, "filehash": "0x0000000000000000000000000000000000000000000000000000000000000000"}, "uri": {"uri": ""}
+            },
             filesPerFolder: []
         };
         let folder = {
-            "name": "TestFolder",
-            "extension": 0,
-            "source": "/bzz-raw:/9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189/",
+            "pointer": {
+                "name": "TestFolder",
+                "extension": 0,
+                "swarm": {
+                    "protocol": 1,
+                    "filehash": "0x9098281bbfb81d161a71c27bae34add67e9fa9f6eb84f22c0c9aedd7b9cd2189"
+                },
+                "ipfs": {"protocol": 0, "filehash": "0x0000000000000000000000000000000000000000000000000000000000000000"}, "uri": {"uri": ""}
+            },
             "parentKey": "0x00",
             filesPerFolder: []
         };
@@ -53,18 +64,20 @@ contract('filesystem', async (accounts) => {
         fileHash = logs[0].args.hash;
 
         let insertedFile = await fileStorage.getByHash(fileHash);
-        assert.equal(file.name, insertedFile.name, 'insertedFile.name incorrect');
-        assert.equal(file.extension, insertedFile.extension, 'insertedFile.extension incorrect');
-        assert.equal(file.source, insertedFile.source, 'insertedFile.source incorrect');
+        assert.equal(file.pointer.name, insertedFile.pointer.name, 'insertedFile.name incorrect');
+        assert.equal(file.pointer.extension, insertedFile.pointer.extension, 'insertedFile.extension incorrect');
+        assert.equal(file.pointer.swarm.protocol, insertedFile.pointer.swarm.protocol, 'insertedFile.swarm incorrect');
+        assert.equal(file.pointer.swarm.filehash, insertedFile.pointer.swarm.filehash, 'insertedFile.filehash incorrect');
         assert.equal(file.parentKey, insertedFile.parentKey, 'insertedFile.parentKey incorrect');
 
         ({logs} = await fileStorage.setFiles(folderHash, [fileHash]));
 
         // Test standalone changeName
         changedFile = await fileFunctions.contract.methods.changeName(file).call();
-        assert.equal(file.name + '1', changedFile.name);
-        assert.equal(file.extension, changedFile.extension);
-        assert.equal(file.source, changedFile.source);
+        assert.equal(file.pointer.name + '1', changedFile.pointer.name);
+        assert.equal(file.pointer.extension, changedFile.pointer.extension);
+        assert.equal(file.pointer.swarm.protocol, changedFile.pointer.swarm.protocol, 'changedFile.swarm incorrect');
+        assert.equal(file.pointer.swarm.filehash, changedFile.pointer.swarm.filehash, 'changedFile.filehash incorrect');
         assert.equal(file.parentKey, changedFile.parentKey);
 
         let funcHash = await dtype.getTypeHash(0, 'changeName');
@@ -72,9 +85,10 @@ contract('filesystem', async (accounts) => {
         ({logs} = await dtype.run(funcHash, [fileHash]));
 
         changedFile = await fileStorage.getByHash(logs[0].args.hash);
-        assert.equal(file.name + '1', changedFile.name, 'changedFile.name incorrect');
-        assert.equal(file.extension, changedFile.extension);
-        assert.equal(file.source, changedFile.source);
+        assert.equal(file.pointer.name + '1', changedFile.pointer.name, 'changedFile.name incorrect');
+        assert.equal(file.pointer.extension, changedFile.pointer.extension);
+        assert.equal(file.pointer.swarm.protocol, changedFile.pointer.swarm.protocol, 'changedFile.swarm incorrect');
+        assert.equal(file.pointer.swarm.filehash, changedFile.pointer.swarm.filehash, 'changedFile.filehash incorrect');
         assert.equal(file.parentKey, changedFile.parentKey);
     });
 });


### PR DESCRIPTION
Filesystem example:
- Add separate libraries for decentralized storage pointers
- Add FilePointer adaptor library and storage contract
- Use FilePointer in FileType
- Update filesystem example data, deployment & tests